### PR TITLE
chore: add a format npm script and use double quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "types": "./lib/index.d.ts",
   "repository": "felipecrs/bindl",
   "scripts": {
-    "build": "rimraf lib && tsc && rimraf --glob 'lib/!(*index).d.ts'",
+    "build": "rimraf lib && tsc && rimraf --glob \"lib/!(*index).d.ts\"",
+    "format": "prettier --write .",
     "lint": "tsc --noEmit && eslint . && prettier --check . && installed-check --ignore-dev",
     "prepack": "npm run build",
     "test": "c8 vitest --no-watch",


### PR DESCRIPTION
Now it works on Windows too