### PR TITLE
chore(build): set target to ES2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "rootDir": "src",


### PR DESCRIPTION
Not super experienced with TypeScript, so I'm unsure if this is already implied by one of the other settings.

If so, feel free to close the PR.