### PR TITLE
fix: windows path separators in binary test command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@xhmikosr/decompress-targz": "^8.1.0",
         "@xhmikosr/decompress-unzip": "^7.1.0",
         "@xhmikosr/downloader": "^15.2.0",
-        "args-tokenizer": "^0.3.0",
         "clipanion": "^4.0.0-rc.4",
         "cosmiconfig": "^9.0.0",
         "listr2": "^9.0.0",
@@ -44,7 +43,7 @@
         "zx": "^8.8.0"
       },
       "engines": {
-        "node": "^20.5.0 || >=22.0.0"
+        "node": "^20.17.0 || >=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2699,12 +2698,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
-    },
-    "node_modules/args-tokenizer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/args-tokenizer/-/args-tokenizer-0.3.0.tgz",
-      "integrity": "sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==",
-      "license": "MIT"
     },
     "node_modules/argv-formatter": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@xhmikosr/decompress-targz": "^8.1.0",
     "@xhmikosr/decompress-unzip": "^7.1.0",
     "@xhmikosr/downloader": "^15.2.0",
-    "args-tokenizer": "^0.3.0",
     "clipanion": "^4.0.0-rc.4",
     "cosmiconfig": "^9.0.0",
     "listr2": "^9.0.0",

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,7 +1,6 @@
 import { chmod, rm } from "node:fs/promises";
 import path from "node:path";
 
-import { tokenizeArgs } from "args-tokenizer";
 import { Command, Option, UsageError } from "clipanion";
 import { cosmiconfig, CosmiconfigResult } from "cosmiconfig";
 import { Listr } from "listr2";
@@ -233,7 +232,9 @@ export class MainCommand extends Command {
 
           for (const test of binary.tests) {
             try {
-              const [command, ...commandArguments] = tokenizeArgs(test.command);
+              const [command, ...commandArguments] = parseCommandString(
+                test.command,
+              );
               const { stdout } = await spawn(command, commandArguments, {
                 cwd: outputDirectory,
               });
@@ -269,3 +270,33 @@ async function importPlugin(plugin: string) {
   const { default: importedPlugin } = await import(plugin);
   return importedPlugin();
 }
+
+// Stolen from https://github.com/sindresorhus/execa/blob/a31fe55782993f2483d30955a8799ab88e20687c/lib/methods/command.js#L18-L43
+// Refs https://github.com/sindresorhus/nano-spawn/issues/14#issuecomment-3156519442
+// Convert `command` string into an array of file or arguments to pass to $`${...fileOrCommandArguments}`
+export const parseCommandString = (command: string) => {
+  const SPACES_REGEXP = / +/g;
+
+  if (typeof command !== "string") {
+    throw new TypeError(`The command must be a string: ${String(command)}.`);
+  }
+
+  const trimmedCommand = command.trim();
+  if (trimmedCommand === "") {
+    return [];
+  }
+
+  const tokens: string[] = [];
+  for (const token of trimmedCommand.split(SPACES_REGEXP)) {
+    // Allow spaces to be escaped by a backslash if not meant as a delimiter
+    const previousToken = tokens.at(-1);
+    if (previousToken && previousToken.endsWith("\\")) {
+      // Merge previous token with current one
+      tokens[tokens.length - 1] = `${previousToken.slice(0, -1)} ${token}`;
+    } else {
+      tokens.push(token);
+    }
+  }
+
+  return tokens;
+};

--- a/test/res/bindl.config.js
+++ b/test/res/bindl.config.js
@@ -89,6 +89,10 @@ export default defineConfig({
       files: [{ source: `shellcheck.exe`, target: "shellcheck.exe" }],
       tests: [
         {
+          command: String.raw`.\shellcheck.exe --version`,
+          expectedOutputContains: `version: ${version}`,
+        },
+        {
           command: "./shellcheck.exe --version",
           expectedOutputContains: `version: ${version}`,
         },
@@ -100,6 +104,10 @@ export default defineConfig({
       url: `${urlPrefix}.zip`,
       // not using "files" to exercise a test
       tests: [
+        {
+          command: String.raw`.\shellcheck.exe --version`,
+          expectedOutputContains: `version: ${version}`,
+        },
         {
           command: "./shellcheck.exe --version",
           expectedOutputContains: `version: ${version}`,


### PR DESCRIPTION
Maybe this [piece of code will become a library someday](https://github.com/sindresorhus/nano-spawn/issues/14#issuecomment-3156654617), and I can remove it from here.

- Refs https://github.com/felipecrs/bindl/pull/882#issuecomment-3156528355